### PR TITLE
Fix quoting so that it'll run on Windows

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -11,7 +11,7 @@ async function getLogLines(
     "log",
     `...${previousVersion}`,
     "--merges",
-    "--grep='Merge pull request'",
+    '--grep="Merge pull request"',
     "--format=format:%s",
     "-z",
     "--"


### PR DESCRIPTION
Ran into this today. Single quotes and Windows apparently does not play nice.

```
(node:10804) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: 'git log ...release-1.0.11 --merges --grep='Merge pull request' --format=format:%s -z --' exited with code 128, signal null
(node:10804) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

cc @joshaber 