### PR TITLE
warn and exit early if token not provided

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
 import { run } from "./run";
 
+if (!process.env.GITHUB_ACCESS_TOKEN) {
+    console.log('You need to provide a GITHUB_ACCESS_TOKEN environment variable')
+    process.exit(1)
+}
+
 const args = process.argv.splice(2);
 run(args);


### PR DESCRIPTION
If you try and run the steps without providing a token, you get overwhelmed with errors:

```shellsession
$ node ../what-the-changelog/ release-1.0.11
Unable to parse line, using the full message. Error: Unable to get PR from API:
3411
    at C:\Users\shiftkey\src\what-the-changelog\out\run.js:80:27
    at Generator.next (<anonymous>)
    at fulfilled (C:\Users\shiftkey\src\what-the-changelog\out\run.js:4:58)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
Unable to parse line, using the full message. Error: Unable to get PR from API:
3690
    at C:\Users\shiftkey\src\what-the-changelog\out\run.js:80:27
    at Generator.next (<anonymous>)
    at fulfilled (C:\Users\shiftkey\src\what-the-changelog\out\run.js:4:58)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
Unable to parse line, using the full message. Error: Unable to get PR from API:
3624
    at C:\Users\shiftkey\src\what-the-changelog\out\run.js:80:27
    at Generator.next (<anonymous>)
    at fulfilled (C:\Users\shiftkey\src\what-the-changelog\out\run.js:4:58)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
Unable to parse line, using the full message. Error: Unable to get PR from API:
3688
    at C:\Users\shiftkey\src\what-the-changelog\out\run.js:80:27
    at Generator.next (<anonymous>)
    at fulfilled (C:\Users\shiftkey\src\what-the-changelog\out\run.js:4:58)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
...
```

Because we really need API access to do some meaningful stuff with the changelog, let's exit early with a more friendly error message:

```shellsession
$ node ../what-the-changelog/ release-1.0.11
You need to provide a GITHUB_ACCESS_TOKEN environment variable
```