### PR TITLE
some other tidy up

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "out/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc"
+    "build": "tsc",
+    "prepack": "npm run build"
   },
   "engines": {
     "node": ">= 8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,9 @@ if (!process.env.GITHUB_ACCESS_TOKEN) {
     process.exit(1)
 }
 
+process.on('unhandledRejection', error => {
+  console.error(error.message);
+});
+
 const args = process.argv.splice(2);
 run(args);


### PR DESCRIPTION
NodeJS has warned about uncaught promises in the process for a while:

```shellsession
$ GITHUB_ACCESS_TOKEN={token} node ../what-the-changelog foo
(node:4836) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: 'git log ...foo --merges --grep="Merge pull request" --format=format:%s -z --' exited with code 128, signal null
(node:4836) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
````

This can be handled and shown without the deprecation warnings:

```
$ GITHUB_ACCESS_TOKEN={token} node ../what-the-changelog foo
'git log ...foo --merges --grep="Merge pull request" --format=format:%s -z --' exited with code 128, signal null
```

Also ensures that you have the latest transpiled code when doing a `npm publish` or `npm pack`.