### PR TITLE
handle some common Git failures

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -103,7 +103,25 @@ async function getChangelogEntries(
 }
 
 export async function run(args: ReadonlyArray<string>): Promise<void> {
+  try {
+    await spawn("git", ["--version"])
+  } catch {
+    throw new Error("Unable to find Git on your PATH, aborting...")
+  }
+
+  try {
+    await spawn("git", ["rev-parse","--show-cdup"])
+  } catch {
+    throw new Error(`The current directory '${process.cwd()}' is not a Git repository, aborting...`)
+  }
+
   const previousVersion = args[0];
+  try {
+    await spawn("git", ["rev-parse", previousVersion])
+  } catch {
+    throw new Error(`Unable to find ref '${previousVersion}' in your repository, aborting...`)
+  }
+
   const lines = await getLogLines(previousVersion);
   const changelogEntries = await getChangelogEntries(lines);
   console.log(jsonStringify(changelogEntries));


### PR DESCRIPTION
This catches some common errors in a more friendly way than the `128` exit code that Git will return (we don't display stderr currently when an error is encountered):

```shellsession
~/src/ GITHUB_ACCESS_TOKEN={token} node what-the-changelog foo
The current directory /Users/shiftkey/src is not a Git repository, aborting...

~/src/ cd desktop

~/src/desktop/ GITHUB_ACCESS_TOKEN={token} node ../what-the-changelog foo
Unable to find ref 'foo' in your repository, aborting...
```
  
  